### PR TITLE
Add UQCP compressor toolkit and Obsidian plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+obsidian-plugin/node_modules/
+obsidian-plugin/dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Lossless
+
+This repository now includes tools for compressing Obsidian vault content into
+UQCP artifacts and an optional Obsidian plugin for triggering compression from
+within the editor.
+
+## Contents
+- `obsidian_uqcp/` – Python toolkit that scans a vault, runs the Ollama-powered
+  compression prompt, writes results to `_compressed`, and can expose a local
+  HTTP API for other clients.
+- `obsidian-plugin/` – Obsidian community plugin source code that calls the
+  local compressor server for the active note.

--- a/obsidian-plugin/README.md
+++ b/obsidian-plugin/README.md
@@ -1,0 +1,35 @@
+# UQCP Compressor Obsidian Plugin
+
+This plugin lets you send the active note in Obsidian to the local UQCP
+compression server (provided by `obsidian_uqcp/compressor.py`) with a single
+command. The server returns the location of the generated `.uqcp.md` artifact,
+and the plugin shows a notice when processing completes.
+
+## Installation
+1. Build the plugin bundle:
+   ```bash
+   npm install
+   npm run build
+   ```
+   The compiled files (`main.js`, `manifest.json`, `styles.css`) will be placed
+   in the `dist/` folder.
+2. Copy the contents of `dist/` into `<vault>/.obsidian/plugins/uqcp-compressor`.
+3. Enable **UQCP Compressor** in Obsidian’s community plugins settings.
+
+## Usage
+- Run the "UQCP: Compress current note" command (Command Palette or assign a
+  hotkey).
+- Ensure the Python compression server is running:
+  ```bash
+  python obsidian_uqcp/compressor.py serve
+  ```
+- Successful compression shows the checksum and destination path in a notice.
+
+## Settings
+- **Endpoint URL** – defaults to `http://127.0.0.1:42121/compress`.
+- **Show response notice** – toggle whether to display the returned checksum and
+  output path.
+
+## Development
+- `npm run dev` will watch for changes and rebuild automatically.
+- Update TypeScript sources in `src/`.

--- a/obsidian-plugin/esbuild.config.mjs
+++ b/obsidian-plugin/esbuild.config.mjs
@@ -1,0 +1,30 @@
+import { build } from "esbuild";
+import { mkdir, cp } from "fs/promises";
+import { join } from "path";
+
+const isProd = process.argv.includes("production");
+
+const outdir = "dist";
+
+async function bundle() {
+  await build({
+    entryPoints: ["src/main.ts"],
+    bundle: true,
+    outfile: join(outdir, "main.js"),
+    format: "cjs",
+    platform: "browser",
+    sourcemap: !isProd,
+    target: "es2018",
+    external: ["obsidian"],
+  });
+
+  await mkdir(outdir, { recursive: true });
+  await cp("manifest.json", join(outdir, "manifest.json"), { recursive: false });
+  await cp("styles.css", join(outdir, "styles.css"), { recursive: false });
+  console.log(`Built plugin (${isProd ? "production" : "dev"})`);
+}
+
+bundle().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,0 +1,11 @@
+{
+  "id": "uqcp-compressor",
+  "name": "UQCP Compressor",
+  "version": "0.1.0",
+  "minAppVersion": "1.4.0",
+  "description": "Send the active note to a local UQCP compression server",
+  "author": "Lossless Tools",
+  "authorUrl": "",
+  "fundingUrl": "",
+  "isDesktopOnly": true
+}

--- a/obsidian-plugin/package.json
+++ b/obsidian-plugin/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "uqcp-compressor",
+  "version": "0.1.0",
+  "description": "Send the active note to a local UQCP compression server",
+  "scripts": {
+    "build": "node esbuild.config.mjs production",
+    "dev": "node esbuild.config.mjs dev"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "esbuild": "^0.21.5",
+    "obsidian": "^1.5.8",
+    "tslib": "^2.6.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -1,0 +1,120 @@
+import { App, Notice, Plugin, PluginSettingTab, Setting, requestUrl, TFile } from "obsidian";
+
+interface UQCPSettings {
+  endpoint: string;
+  showNotice: boolean;
+}
+
+const DEFAULT_SETTINGS: UQCPSettings = {
+  endpoint: "http://127.0.0.1:42121/compress",
+  showNotice: true,
+};
+
+interface CompressionResponse {
+  status?: string;
+  path?: string;
+  output?: string;
+  checksum?: string;
+  error?: string;
+}
+
+export default class UQCPCompressorPlugin extends Plugin {
+  settings: UQCPSettings = DEFAULT_SETTINGS;
+
+  async onload() {
+    await this.loadSettings();
+
+    this.addCommand({
+      id: "uqcp-compress-current-note",
+      name: "UQCP: Compress current note",
+      callback: () => this.compressActiveNote(),
+    });
+
+    this.addSettingTab(new UQCPSettingTab(this.app, this));
+  }
+
+  async compressActiveNote() {
+    const file = this.getActiveMarkdownFile();
+    if (!file) {
+      new Notice("No Markdown note is active.");
+      return;
+    }
+
+    const content = await this.app.vault.read(file);
+    try {
+      const response = await requestUrl({
+        url: this.settings.endpoint,
+        method: "POST",
+        body: JSON.stringify({ path: file.path, content }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const data = response.json as CompressionResponse;
+      if (data.error) {
+        new Notice(`UQCP compression failed: ${data.error}`);
+        return;
+      }
+
+      if (this.settings.showNotice) {
+        const checksum = data.checksum ?? "unknown";
+        const output = data.output ?? "unknown";
+        new Notice(`UQCP OK\nChecksum: ${checksum}\nOutput: ${output}`);
+      }
+    } catch (error) {
+      console.error(error);
+      new Notice("UQCP request failed. Ensure the server is running.");
+    }
+  }
+
+  getActiveMarkdownFile(): TFile | null {
+    const file = this.app.workspace.getActiveFile();
+    if (!file || file.extension !== "md") {
+      return null;
+    }
+    return file;
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
+}
+
+class UQCPSettingTab extends PluginSettingTab {
+  constructor(app: App, private plugin: UQCPCompressorPlugin) {
+    super(app, plugin);
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    containerEl.createEl("h2", { text: "UQCP Compressor" });
+
+    new Setting(containerEl)
+      .setName("Endpoint URL")
+      .setDesc("Address of the local compression server")
+      .addText((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.endpoint)
+          .setValue(this.plugin.settings.endpoint)
+          .onChange(async (value) => {
+            this.plugin.settings.endpoint = value.trim() || DEFAULT_SETTINGS.endpoint;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+    new Setting(containerEl)
+      .setName("Show response notice")
+      .setDesc("Display checksum/output after compression")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.showNotice).onChange(async (value) => {
+          this.plugin.settings.showNotice = value;
+          await this.plugin.saveSettings();
+        }),
+      );
+  }
+}

--- a/obsidian-plugin/styles.css
+++ b/obsidian-plugin/styles.css
@@ -1,0 +1,1 @@
+/* Optional styles for notices or future UI */

--- a/obsidian-plugin/tsconfig.json
+++ b/obsidian-plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["DOM", "ES2020"],
+    "types": ["node", "obsidian"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noImplicitAny": false,
+    "sourceMap": true,
+    "outDir": "build"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/obsidian_uqcp/README.md
+++ b/obsidian_uqcp/README.md
@@ -1,0 +1,60 @@
+# Obsidian → UQCP Compressor Toolkit
+
+This toolkit provides a repeatable pipeline for converting Markdown notes in an
+Obsidian vault into **UQCP (Ultra-Quick Compression Protocol)** artifacts using
+a local Ollama model. Outputs are written to a parallel `_compressed` folder
+inside your vault, and a manifest is generated for downstream tooling.
+
+## Features
+- Walk an Obsidian vault, filter Markdown notes, and compress each note with a
+  structured prompt.
+- Optional cache so previously processed notes are skipped unless content
+  changes.
+- Folder-level aggregation that merges note artifacts into `_folder_aggregate`
+  files for high-level review.
+- Optional HTTP server so other tools (for example, the included Obsidian
+  plugin) can request on-demand compression of the active note.
+
+## Requirements
+- Python 3.9+
+- [Ollama](https://ollama.com/) running locally
+- Python dependencies listed in `requirements.txt`
+
+## Quick start
+1. Install dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   pip install -r requirements.txt
+   ```
+2. Update `config.yaml` so that `vault_path` points to your Obsidian vault.
+3. Run the compressor:
+   ```bash
+   python compressor.py run --full
+   ```
+
+### Incremental updates
+```bash
+python compressor.py run --changed-only
+```
+
+### Serve HTTP endpoint
+Start a local server that other apps can call:
+```bash
+python compressor.py serve --host 127.0.0.1 --port 42121
+```
+
+### Configuration
+See `config.yaml` for model, prompt, and filtering options. Prompt text is
+stored in `prompts/uqcp_prompt.txt` so it can be customised without editing the
+code.
+
+## Outputs
+- Per-note artifacts saved as `<note>.uqcp.md` in `_compressed` mirror folders.
+- `_index.json` manifest summarising operations.
+- `_folder_aggregate.uqcp.md` files when aggregation is enabled.
+
+## Integrations
+The `/obsidian-plugin` directory contains a companion Obsidian plugin that can
+send the currently active note to the HTTP server for compression without
+leaving Obsidian.

--- a/obsidian_uqcp/compressor.py
+++ b/obsidian_uqcp/compressor.py
@@ -1,0 +1,385 @@
+"""Obsidian → UQCP compressor.
+
+Scan an Obsidian vault, push Markdown files through an Ollama prompt, and write
+compressed artifacts. Can also run a lightweight HTTP server so external tools
+can request compression for a single note on demand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import http.server
+import json
+import logging
+import os
+import socketserver
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import requests
+import yaml
+from tqdm import tqdm
+
+CONFIG_PATH = Path(__file__).with_name("config.yaml")
+PROMPT_PATH = Path(__file__).parent / "prompts" / "uqcp_prompt.txt"
+CACHE_FILE = "_cache.json"
+INDEX_FILE = "_index.json"
+AGGREGATE_FILE = "_folder_aggregate.uqcp.md"
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+logger = logging.getLogger("uqcp")
+
+
+@dataclass
+class Config:
+    vault_path: Path
+    output_folder_name: str
+    ollama_host: str
+    ollama_model: str
+    ollama_temperature: float
+    ollama_num_ctx: int
+    changed_only: bool
+    max_section_chars: int
+    aggregate_by_folder: bool
+    include_extensions: List[str]
+    exclude_folders: List[str]
+    server_host: str
+    server_port: int
+
+    @staticmethod
+    def from_dict(data: Dict) -> "Config":
+        return Config(
+            vault_path=Path(data["vault_path"]).expanduser(),
+            output_folder_name=data.get("output_folder_name", "_compressed"),
+            ollama_host=data["ollama"]["host"],
+            ollama_model=data["ollama"]["model"],
+            ollama_temperature=float(data["ollama"].get("temperature", 0.2)),
+            ollama_num_ctx=int(data["ollama"].get("num_ctx", 120000)),
+            changed_only=bool(data.get("processing", {}).get("changed_only", False)),
+            max_section_chars=int(data.get("processing", {}).get("max_section_chars", 18000)),
+            aggregate_by_folder=bool(data.get("processing", {}).get("aggregate_by_folder", True)),
+            include_extensions=[ext.lower() for ext in data.get("filters", {}).get("include_extensions", [".md"])],
+            exclude_folders=[fld for fld in data.get("filters", {}).get("exclude_folders", [])],
+            server_host=data.get("server", {}).get("host", "127.0.0.1"),
+            server_port=int(data.get("server", {}).get("port", 42121)),
+        )
+
+
+def load_config() -> Config:
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError(f"Config file not found: {CONFIG_PATH}")
+    with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return Config.from_dict(data)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def split_frontmatter(text: str) -> Tuple[str, str]:
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) >= 3:
+            return parts[1].strip(), parts[2].lstrip()
+    return "", text
+
+
+def chunk_text(text: str, max_chars: int) -> List[str]:
+    if len(text) <= max_chars:
+        return [text]
+    chunks: List[str] = []
+    cursor = 0
+    while cursor < len(text):
+        chunks.append(text[cursor : cursor + max_chars])
+        cursor += max_chars
+    return chunks
+
+
+def build_prompt(template: str, *, title: str, path: Path, frontmatter: str, body: str) -> str:
+    prompt = template
+    prompt = prompt.replace("{{title}}", title)
+    prompt = prompt.replace("{{path}}", str(path))
+    prompt = prompt.replace("{{frontmatter}}", frontmatter if frontmatter else "(none)")
+    prompt = prompt.replace("{{body}}", body)
+    return prompt
+
+
+def sha1(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()
+
+
+def sha256(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def call_ollama(host: str, model: str, prompt: str, *, temperature: float, num_ctx: int) -> str:
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "stream": False,
+        "options": {"temperature": temperature, "num_ctx": num_ctx},
+    }
+    response = requests.post(f"{host.rstrip('/')}/api/generate", json=payload, timeout=1200)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("response", "")
+
+
+def discover_files(root: Path, *, include_exts: Iterable[str], exclude_folders: Iterable[str]) -> List[Path]:
+    include = tuple(include_exts)
+    exclude = set(exclude_folders)
+    files: List[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in exclude]
+        for filename in filenames:
+            if filename.lower().endswith(include):
+                files.append(Path(dirpath) / filename)
+    return files
+
+
+def load_prompt_template() -> str:
+    if not PROMPT_PATH.exists():
+        raise FileNotFoundError(f"Prompt template not found: {PROMPT_PATH}")
+    return read_text(PROMPT_PATH)
+
+
+def load_cache(path: Path) -> Dict[str, str]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(read_text(path))
+    except Exception:
+        logger.warning("Cache file is corrupted, rebuilding")
+        return {}
+
+
+def save_cache(path: Path, data: Dict[str, str]) -> None:
+    write_text(path, json.dumps(data, indent=2))
+
+
+def compress_markdown(path: Path, *, cfg: Config, prompt_template: str, cache: Dict[str, str], out_dir: Path) -> Dict[str, str]:
+    raw = read_text(path)
+    frontmatter, body = split_frontmatter(raw)
+    sections = chunk_text(body, cfg.max_section_chars)
+    prepared_body = []
+    for idx, chunk in enumerate(sections, start=1):
+        prepared_body.append(f"[SECTION {idx}/{len(sections)}]\n{chunk.strip()}\n")
+    full_body = "\n".join(prepared_body)
+    prompt = build_prompt(
+        prompt_template,
+        title=path.stem,
+        path=path,
+        frontmatter=frontmatter,
+        body=full_body,
+    )
+    cache_key = sha1(prompt)
+    rel_key = str(path)
+    if cfg.changed_only and cache.get(rel_key) == cache_key:
+        return {"path": rel_key, "status": "skipped"}
+
+    response = call_ollama(
+        cfg.ollama_host,
+        cfg.ollama_model,
+        prompt,
+        temperature=cfg.ollama_temperature,
+        num_ctx=cfg.ollama_num_ctx,
+    )
+    checksum = sha256(response)
+    response = response.replace(
+        "Checksum_Placeholder: \"TO_BE_FILLED_BY_TOOL\"",
+        f"Checksum: {checksum}",
+    )
+    relative_dir = path.parent.relative_to(cfg.vault_path)
+    destination = out_dir / relative_dir
+    destination.mkdir(parents=True, exist_ok=True)
+    out_file = destination / f"{path.stem}.uqcp.md"
+    write_text(out_file, response)
+    cache[rel_key] = cache_key
+    return {
+        "path": rel_key,
+        "status": "ok",
+        "output": str(out_file),
+        "checksum": checksum,
+    }
+
+
+def aggregate_folder(folder: Path) -> Optional[Path]:
+    parts: List[str] = []
+    for child in sorted(folder.glob("*.uqcp.md")):
+        if child.name == AGGREGATE_FILE:
+            continue
+        parts.append(f"\n\n---\n# {child.stem}\n\n{read_text(child)}")
+    if not parts:
+        return None
+    aggregate = "".join(parts)
+    out_path = folder / AGGREGATE_FILE
+    write_text(out_path, aggregate)
+    return out_path
+
+
+def run_pipeline(cfg: Config, *, full: bool, changed_only: bool, target_folder: Optional[str]) -> None:
+    prompt_template = load_prompt_template()
+    vault = cfg.vault_path
+    if not vault.exists():
+        raise FileNotFoundError(f"Vault path does not exist: {vault}")
+
+    working_cfg = cfg
+    if full:
+        working_cfg = dataclasses.replace(cfg, changed_only=False)
+    elif changed_only:
+        working_cfg = dataclasses.replace(cfg, changed_only=True)
+
+    if target_folder:
+        root = vault / target_folder
+    else:
+        root = vault
+
+    out_dir = vault / cfg.output_folder_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cache_path = out_dir / CACHE_FILE
+    cache = load_cache(cache_path)
+
+    files = discover_files(root, include_exts=working_cfg.include_extensions, exclude_folders=working_cfg.exclude_folders + [cfg.output_folder_name])
+    results: List[Dict[str, str]] = []
+    for path in tqdm(files, desc="Compressing"):
+        try:
+            results.append(
+                compress_markdown(
+                    path,
+                    cfg=working_cfg,
+                    prompt_template=prompt_template,
+                    cache=cache,
+                    out_dir=out_dir,
+                )
+            )
+        except Exception as exc:  # log and continue
+            logger.exception("Failed to process %s", path)
+            results.append({"path": str(path), "status": "error", "error": str(exc)})
+
+    save_cache(cache_path, cache)
+
+    if working_cfg.aggregate_by_folder:
+        for dirpath, _, filenames in os.walk(out_dir):
+            if any(name.endswith(".uqcp.md") for name in filenames):
+                aggregate_folder(Path(dirpath))
+
+    write_text(out_dir / INDEX_FILE, json.dumps(results, indent=2))
+    logger.info("Processed %d files", len(results))
+
+
+class CompressionHandler(http.server.BaseHTTPRequestHandler):
+    cfg: Config = load_config()
+    prompt_template: str = load_prompt_template()
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/compress":
+            self.send_error(404, "Not found")
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        try:
+            payload = json.loads(self.rfile.read(length)) if length else {}
+        except json.JSONDecodeError:
+            self.send_error(400, "Invalid JSON payload")
+            return
+
+        note_path = payload.get("path")
+        content = payload.get("content")
+        if not note_path or content is None:
+            self.send_error(400, "Missing 'path' or 'content'")
+            return
+
+        note_path = str(note_path)
+        target = self.cfg.vault_path / note_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        write_text(target, content)
+        out_dir = self.cfg.vault_path / self.cfg.output_folder_name
+        cache_path = out_dir / CACHE_FILE
+        cache = load_cache(cache_path)
+        # Always reprocess direct requests to ensure fresh output.
+        local_cfg = dataclasses.replace(self.cfg, changed_only=False)
+        result = compress_markdown(
+            target,
+            cfg=local_cfg,
+            prompt_template=self.prompt_template,
+            cache=cache,
+            out_dir=out_dir,
+        )
+        # Refresh aggregate for this folder when enabled.
+        if local_cfg.aggregate_by_folder:
+            try:
+                relative_parent = target.parent.relative_to(local_cfg.vault_path)
+            except ValueError:
+                relative_parent = Path(".")
+            note_output_dir = out_dir / relative_parent
+            if note_output_dir.exists():
+                aggregate_folder(note_output_dir)
+        save_cache(cache_path, cache)
+        response = json.dumps(result).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        logger.info("Server: " + format, *args)
+
+
+def serve(cfg: Config, *, host: str, port: int) -> None:
+    handler = CompressionHandler
+    handler.cfg = cfg
+    handler.prompt_template = load_prompt_template()
+    socketserver.ThreadingTCPServer.allow_reuse_address = True
+    with socketserver.ThreadingTCPServer((host, port), handler) as httpd:
+        logger.info("Serving compression API on http://%s:%s", host, port)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            logger.info("Shutting down")
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Obsidian → UQCP compressor")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = sub.add_parser("run", help="Run compression pipeline")
+    run_parser.add_argument("--full", action="store_true", help="Rebuild everything")
+    run_parser.add_argument("--changed-only", action="store_true", help="Only process changed files")
+    run_parser.add_argument("--folder", type=str, help="Process a specific folder relative to the vault")
+
+    serve_parser = sub.add_parser("serve", help="Start HTTP server")
+    serve_parser.add_argument("--host", type=str, help="Listen host")
+    serve_parser.add_argument("--port", type=int, help="Listen port")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+    cfg = load_config()
+
+    if args.command == "run":
+        run_pipeline(cfg, full=args.full, changed_only=args.changed_only, target_folder=args.folder)
+    elif args.command == "serve":
+        host = args.host or cfg.server_host
+        port = args.port or cfg.server_port
+        serve(cfg, host=host, port=port)
+    else:
+        raise ValueError(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/obsidian_uqcp/config.yaml
+++ b/obsidian_uqcp/config.yaml
@@ -1,0 +1,17 @@
+vault_path: "/path/to/your/vault"  # Change to your Obsidian vault
+output_folder_name: "_compressed"
+ollama:
+  host: "http://localhost:11434"
+  model: "llama3.1"
+  temperature: 0.2
+  num_ctx: 120000
+processing:
+  changed_only: false
+  max_section_chars: 18000
+  aggregate_by_folder: true
+filters:
+  include_extensions: [".md", ".markdown"]
+  exclude_folders: [".git", ".obsidian", "_compressed"]
+server:
+  host: "127.0.0.1"
+  port: 42121

--- a/obsidian_uqcp/prompts/uqcp_prompt.txt
+++ b/obsidian_uqcp/prompts/uqcp_prompt.txt
@@ -1,0 +1,61 @@
+# UQCP_COMPRESSION_PROTOCOL (Σ{Ψ⊗∇}⟨θ∀π⟩[Ω])
+You are the **Algorithmic Interpreter (∇)** assisting the **Visionary Architect (Ψ)**.
+Compress the given Markdown note into a **lossless, re-initialisation artifact**
+for future AI instances. Maintain **maximum density**, **minimal redundancy**,
+and **explicit decompression instructions**. If content is missing or ambiguous,
+be honest and mark it.
+
+## Inputs
+- Note Title: {{title}}
+- File Path: {{path}}
+- Frontmatter (YAML):
+{{frontmatter}}
+
+- Body (truncated/sectioned as needed):
+{{body}}
+
+## Output Spec (emit in this exact order)
+
+### YAML (--- fenced)
+- Framework_Core (name, axioms, master_equation if present)
+- Document_ID (stable hash if provided or derived)
+- Source_Metadata (path, title, headings, links)
+- Claims (list of distilled claims with pointers to sections)
+- Predictions / Falsifiables (if any)
+- Dependencies (concepts/laws this note relies on)
+- Relations (links to other notes if referenced)
+- Integrity (assumptions, unknowns, TODOs)
+
+### JSON (```json fenced)
+- Core_Principles (booleans/keys)
+- Components (array of {name,function})
+- Narrative_Anchor (if any parable/story exists)
+- Parameters (symbols used, brief defs)
+- Exports (recommended tags, keywords)
+
+### Symbolic Logic (```text fenced)
+Include 2–6 lines of propositional/first-order relations mirroring core claims.
+Keep it tight; no more than ~8 symbols per line when possible.
+
+### Pseudocode (```text fenced)
+Provide 5–15 lines capturing the algorithmic essence, including inputs/outputs.
+Prefer function signatures and concise steps.
+
+### Emoji Fusion (one line)
+One line of emojis that conveys the conceptual blend.
+
+### Meta-Cognitive Integration Summary (```text fenced)
+- User Intent (≤35 words)
+- Conversation Arc (≤35 words, if inferable)
+- Breakthrough Insight (≤35 words)
+- AI Role (≤20 words)
+
+### Decompression Instructions (```text fenced)
+Exact steps for reconstructing the note’s original meaning from this artifact.
+Reference YAML/JSON keys as anchors.
+
+### Recovery
+- Recovery_Key: short SNAKE_CASE token
+- Checksum_Placeholder: "TO_BE_FILLED_BY_TOOL"
+
+End strictly.

--- a/obsidian_uqcp/requirements.txt
+++ b/obsidian_uqcp/requirements.txt
@@ -1,0 +1,4 @@
+markdown-it-py>=3.0.0
+pyyaml>=6.0.0
+requests>=2.31.0
+tqdm>=4.66.0


### PR DESCRIPTION
## Summary
- add a Python-based UQCP compressor with Ollama integration, caching, aggregation, and optional HTTP server
- document configuration, prompt, and requirements for running the vault pipeline
- add an Obsidian plugin that posts the active note to the local compression server and reports the result

## Testing
- python -m compileall obsidian_uqcp/compressor.py

------
https://chatgpt.com/codex/tasks/task_e_68d7302a680083318c65ea4a62bb2bbb